### PR TITLE
vecX: add setLength function

### DIFF
--- a/src/vec2-impl.ts
+++ b/src/vec2-impl.ts
@@ -671,7 +671,7 @@ export function rotate(a: Vec2, b: Vec2, rad: number, dst?: Vec2) {
 /**
  * Treat a 2D vector as a direction and set it's length
  *
- * @param a The vec2 to length
+ * @param a The vec2 to lengthen
  * @param len The length of the resulting vector
  * @returns The lengthened vector
  */

--- a/src/vec2-impl.ts
+++ b/src/vec2-impl.ts
@@ -667,3 +667,16 @@ export function rotate(a: Vec2, b: Vec2, rad: number, dst?: Vec2) {
 
   return dst;
 }
+
+/**
+ * Treat a 2D vector as a direction and set it's length
+ *
+ * @param a The vec2 to length
+ * @param len The length of the resulting vector
+ * @returns The lengthened vector
+ */
+export function setLength(a: Vec2, len: number, dst?: Vec2) {
+  dst = dst || new VecType(2);
+  normalize(a, dst);
+  return mulScalar(dst, len, dst);
+}

--- a/src/vec3-impl.ts
+++ b/src/vec3-impl.ts
@@ -887,7 +887,7 @@ export function rotateZ(a: Vec3, b: Vec3, rad: number, dst?: Vec3) {
 /**
  * Treat a 3D vector as a direction and set it's length
  *
- * @param a The vec3 to length
+ * @param a The vec3 to lengthen
  * @param len The length of the resulting vector
  * @returns The lengthened vector
  */

--- a/src/vec3-impl.ts
+++ b/src/vec3-impl.ts
@@ -883,3 +883,16 @@ export function rotateZ(a: Vec3, b: Vec3, rad: number, dst?: Vec3) {
 
   return dst;
 }
+
+/**
+ * Treat a 3D vector as a direction and set it's length
+ *
+ * @param a The vec3 to length
+ * @param len The length of the resulting vector
+ * @returns The lengthened vector
+ */
+export function setLength(a: Vec3, len: number, dst?: Vec3) {
+  dst = dst || new VecType(3);
+  normalize(a, dst);
+  return mulScalar(dst, len, dst);
+}

--- a/src/vec4-impl.ts
+++ b/src/vec4-impl.ts
@@ -637,7 +637,7 @@ export function transformMat4(v: Vec4, m: Mat4, dst?: Vec4): Vec4 {
 /**
  * Treat a 4D vector as a direction and set it's length
  *
- * @param a The vec3 to length
+ * @param a The vec3 to lengthen
  * @param len The length of the resulting vector
  * @returns The lengthened vector
  */

--- a/src/vec4-impl.ts
+++ b/src/vec4-impl.ts
@@ -632,3 +632,17 @@ export function transformMat4(v: Vec4, m: Mat4, dst?: Vec4): Vec4 {
 
   return dst;
 }
+
+
+/**
+ * Treat a 4D vector as a direction and set it's length
+ *
+ * @param a The vec3 to length
+ * @param len The length of the resulting vector
+ * @returns The lengthened vector
+ */
+export function setLength(a: Vec4, len: number, dst?: Vec4) {
+  dst = dst || new VecType(4);
+  normalize(a, dst);
+  return mulScalar(dst, len, dst);
+}

--- a/src/vec4-impl.ts
+++ b/src/vec4-impl.ts
@@ -637,7 +637,7 @@ export function transformMat4(v: Vec4, m: Mat4, dst?: Vec4): Vec4 {
 /**
  * Treat a 4D vector as a direction and set it's length
  *
- * @param a The vec3 to lengthen
+ * @param a The vec4 to lengthen
  * @param len The length of the resulting vector
  * @returns The lengthened vector
  */

--- a/test/tests/vec2-test.js
+++ b/test/tests/vec2-test.js
@@ -503,7 +503,7 @@ describe('vec2', () => {
         vecA = [1, 1];
         result = vec2.setLength(vecA, 14.6);
       });
-      it("should return the rotated vector", function () {
+      it("should return the lengthend vector", function () {
         assertEqualApproximately(result, [10.323759005323593, 10.323759005323593]);
         assertEqualApproximately(vec2.length(result), 14.6);
       });

--- a/test/tests/vec2-test.js
+++ b/test/tests/vec2-test.js
@@ -496,5 +496,19 @@ describe('vec2', () => {
     });
   });
 
+  describe('setLength', function() {
+    describe('set the length of a provided direction vector', function() {
+      let vecA, result;
+      beforeEach(function () {
+        vecA = [1, 1];
+        result = vec2.setLength(vecA, 14.6);
+      });
+      it("should return the rotated vector", function () {
+        assertEqualApproximately(result, [10.323759005323593, 10.323759005323593]);
+        assertEqualApproximately(vec2.length(result), 14.6);
+      });
+    });
+  });
+
 });
 

--- a/test/tests/vec3-test.js
+++ b/test/tests/vec3-test.js
@@ -559,7 +559,7 @@ describe('vec3', () => {
         vecA = [1, 1, 1];
         result = vec3.setLength(vecA, 14.6);
       });
-      it("should return the rotated vector", function () {
+      it("should return the lengthened vector", function () {
         assertEqualApproximately(result, [8.429313930168536, 8.429313930168536, 8.429313930168536]);
         assertEqualApproximately(vec3.length(result), 14.6);
       });

--- a/test/tests/vec3-test.js
+++ b/test/tests/vec3-test.js
@@ -551,5 +551,20 @@ describe('vec3', () => {
         });
     });
   });
+
+  describe('setLength', function() {
+    describe('set the length of a provided direction vector', function() {
+      let vecA, result;
+      beforeEach(function () {
+        vecA = [1, 1, 1];
+        result = vec3.setLength(vecA, 14.6);
+      });
+      it("should return the rotated vector", function () {
+        assertEqualApproximately(result, [8.429313930168536, 8.429313930168536, 8.429313930168536]);
+        assertEqualApproximately(vec3.length(result), 14.6);
+      });
+    });
+  });
+
 });
 

--- a/test/tests/vec4-test.js
+++ b/test/tests/vec4-test.js
@@ -7,6 +7,7 @@ import {
   assertStrictEqual,
   assertStrictNotEqual,
   assertIsArray,
+  assertEqualApproximately,
   assertTruthy,
   assertFalsy,
 } from '../assert.js';
@@ -403,6 +404,20 @@ describe('vec4', () => {
   check(Array);
   check(Float32Array);
   check(Float64Array);
+
+  describe('setLength', function() {
+    describe('set the length of a provided direction vector', function() {
+      let vecA, result;
+      beforeEach(function () {
+        vecA = [1, 1, 1, 1];
+        result = vec4.setLength(vecA, 14.6);
+      });
+      it("should return the rotated vector", function () {
+        assertEqualApproximately(result, [7.3, 7.3, 7.3, 7.3]);
+        assertEqualApproximately(vec4.length(result), 14.6);
+      });
+    });
+  });
 
 });
 

--- a/test/tests/vec4-test.js
+++ b/test/tests/vec4-test.js
@@ -412,7 +412,7 @@ describe('vec4', () => {
         vecA = [1, 1, 1, 1];
         result = vec4.setLength(vecA, 14.6);
       });
-      it("should return the rotated vector", function () {
+      it("should return the lengthened vector", function () {
         assertEqualApproximately(result, [7.3, 7.3, 7.3, 7.3]);
         assertEqualApproximately(vec4.length(result), 14.6);
       });


### PR DESCRIPTION
I've found this useful in scenarios where I'm treating an existing vector as a direction, and want to set it to a specific length. (e.g., updating the `speed` component a velocity vector for a moving object without changing it's `direction` component.)