### PR TITLE
Fix: magnitude calculation issue in vec2 and vec3 angle functions

### DIFF
--- a/src/vec2-impl.ts
+++ b/src/vec2-impl.ts
@@ -158,8 +158,8 @@ export function addScaled(a: Vec2, b: Vec2, scale: number, dst?: Vec2) {
 export function angle(a: Vec2, b: Vec2): number {
   const ax = a[0];
   const ay = a[1];
-  const bx = a[0];
-  const by = a[1];
+  const bx = b[0];
+  const by = b[1];
   const mag1 = Math.sqrt(ax * ax + ay * ay);
   const mag2 = Math.sqrt(bx * bx + by * by);
   const mag = mag1 * mag2;

--- a/src/vec3-impl.ts
+++ b/src/vec3-impl.ts
@@ -168,9 +168,9 @@ export function angle(a: Vec3, b: Vec3): number {
   const ax = a[0];
   const ay = a[1];
   const az = a[2];
-  const bx = a[0];
-  const by = a[1];
-  const bz = a[2];
+  const bx = b[0];
+  const by = b[1];
+  const bz = b[2];
   const mag1 = Math.sqrt(ax * ax + ay * ay + az * az);
   const mag2 = Math.sqrt(bx * bx + by * by + bz * bz);
   const mag = mag1 * mag2;

--- a/test/tests/vec2-test.js
+++ b/test/tests/vec2-test.js
@@ -102,7 +102,7 @@ function check(Type) {
         { a: [1, 0], b: [ 0, 1], expected: Math.PI / 2, },
         { a: [1, 0], b: [-1, 0], expected: Math.PI, },
         { a: [1, 0], b: [ 1, 0], expected: 0, },
-        { a: [1, 2], b: [ 4, 5], expected: 0.225726 },
+        { a: [1, 2], b: [ 4, 5], expected: 0.2110933, },
         { a: [1, 0], b: [ 0, Number.POSITIVE_INFINITY], expected: Math.PI / 2, },
       ];
       for (const {a, b, expected} of tests) {

--- a/test/tests/vec3-test.js
+++ b/test/tests/vec3-test.js
@@ -102,7 +102,7 @@ function check(Type) {
         { a: [1, 0, 0], b: [ 0, 1, 0], expected: Math.PI / 2, },
         { a: [1, 0, 0], b: [-1, 0, 0], expected: Math.PI, },
         { a: [1, 0, 0], b: [ 1, 0, 0], expected: 0, },
-        { a: [1, 2, 3], b: [ 4, 5, 6], expected: 0.225726 },
+        { a: [1, 2, 3], b: [ 4, 5, 6], expected: 0.2257261 },
         { a: [1, 0, 0], b: [ 0, Number.POSITIVE_INFINITY, 0], expected: Math.PI / 2, },
       ];
       for (const {a, b, expected} of tests) {


### PR DESCRIPTION
The vec2 and vec3 angle functions don't use vector b for magnitude calculation.

- Fixed angle functions to use vector b
- Updated tests to use more accurate rotation number
