### PR TITLE
Correct URL for minified version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ There is also the minified version
 import {
   vec3,
   mat4,
-} from 'https://wgpu-matrix.org/dist/2.x/wgpu-matrix.module.js';
+} from 'https://wgpu-matrix.org/dist/2.x/wgpu-matrix.min.js';
 
 // ... etc ...
 ```


### PR DESCRIPTION
The most recent change for this line was from `wgpu-matrix.module.min.js` to `wgpu-matrix.module.js`,
but this sample code is supposed to be showing how to use the minified version, so `wgpu-matrix.min.js`
appears to be most appropriate.