### PR TITLE
feat: a wider BaseArgType

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,8 @@
  * values.
  */
 export interface MutableNumberArray {
-	readonly length: number;
-	[n: number]: number;
+  readonly length: number;
+  [n: number]: number;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,19 @@
 /**
+ * A type wider than `number[]`, omitting any instance functions
+ * unused by the API, e.g., map, sort. This allows the math
+ * functions to operate on a wider range of array-like
+ * values.
+ */
+export interface MutableNumberArray {
+	readonly length: number;
+	[n: number]: number;
+}
+
+/**
  * The types you can pass to most functions that take an
  * array of numbers.
  */
-export type BaseArgType = Float32Array | Float64Array | number[];
+export type BaseArgType = Float32Array | Float64Array | MutableNumberArray;
 
 function wrapConstructor<T extends new(...args: any[]) => any>(
   OriginalConstructor: T,

--- a/src/wgpu-matrix.ts
+++ b/src/wgpu-matrix.ts
@@ -2,7 +2,7 @@
  * Some docs
  * @namespace wgpu-matrix
  */
-import {BaseArgType, ZeroArray} from './types';
+import {MutableNumberArray, BaseArgType, ZeroArray} from './types';
 import {Mat3Arg, Mat3Type, getAPI as getMat3API} from './mat3-impl';
 import {Mat4Arg, Mat4Type, getAPI as getMat4API} from './mat4-impl';
 import {QuatArg, QuatType, getAPI as getQuatAPI, RotationOrder} from './quat-impl';
@@ -15,6 +15,7 @@ export {
   RotationOrder,
   utils,
 
+  MutableNumberArray,
   BaseArgType,
 
   Mat3Arg,


### PR DESCRIPTION
Hi! First of all, awesome library 👏!

We are currently working on improving interop between TypeGPU and wgpu-matrix, and to do that, we plan to expose an `arrayView` property on our vectors and matrix primitives that gives access to the underlying data in the form of a flat array of numbers. Since its just a view, we only wanted to expose the necessities, like a `length` property, and getters/setters for numeric properties. ([Relevant issue](https://github.com/software-mansion/TypeGPU/issues/485))

To make this possible, I was wondering if wgpu-matrix could have a wider type restriction, since it seems to operate solely on the `length` prop and numeric properties.